### PR TITLE
Added option to not translate into Greeklish

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ if ($parsed_address) {
 ```
 
 ## Options
-So far, there is one option that can be passed as follows:
+Options are passed in an array in the third parameter of the call to get_parsed_address, for example:
 ```php
 $parser->get_parsed_address($vat, $address, ['sk_delete_mc']);
 ```
 
-sk_delete_mc deletes "Mestka cast" or its abbreviation "m. c. " from the city name for Slovakian VATs. This is to save space, it is unnecessary to have it in an address
+Available options are:
+
+- ```sk_delete_mc``` deletes "Mestka cast" or its abbreviation "m. c. " from the city name for Slovakian VATs. This is to save space, it is unnecessary to have it in an address
+- ```do_not_greeklish``` do not attempt to convert Greek language addresses to latin characters
 
 
 ## Notes

--- a/src/ViesParser/ViesParser.php
+++ b/src/ViesParser/ViesParser.php
@@ -26,7 +26,7 @@ class ViesParser {
         -IE has pretty much unparsable addresses in VIES - split by commas, in different orders, without zip codes, often without street number etc
         -ES VIES does not return address unless you tell it what it is
         -RO does not have ZIP codes in VIES data, but we parse the rest. ZIP will return false - needs to be input by customer manualy
-        -EL additionaly gets transliterated to English characters (resulting in Greeklish)
+        -EL additionaly gets transliterated to English characters (resulting in Greeklish - if not excluded by config flags)
 
         */
         if (!in_array($country_code, $this-> get_supported_countries())) {
@@ -63,7 +63,11 @@ class ViesParser {
 
 
         if ($newlines == 0 and in_array($country_code, ['EL']) ){
-            $address = $this->make_greeklish($address);
+            if (in_array('do_not_greeklish', $config_flags)) {
+                $address = $address;
+            } else {
+                $address = $this->make_greeklish($address);
+            }
             $hyphen_pos = strpos($address, ' - ');
             $city = substr($address, $hyphen_pos+3);
             $address_without_city = substr($address, 0, $hyphen_pos);


### PR DESCRIPTION
I am working on a Greek website and we do not want the address to be translated into Greeklish. So I added an option to skip this step for Greek VAT numbers only, default to off. Also updated the README.MD to reflect this.